### PR TITLE
Fix minor coding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The hyper transformer is also capable of transforming all of the tables specifie
 >>> meta_file = 'data/Airbnb_demo_meta.json'
 >>> ht = HyperTransformer(meta_file)
 >>> tl = ['DTTransformer', 'NumberTransformer']
->>> transformed = ht.hyper_fit_transform(transformer_list=tl)
+>>> transformed = ht.fit_transform(transformer_list=tl)
 >>>
 {'sessions':        secs_elapsed  ?secs_elapsed
 0             319.0              1
@@ -136,7 +136,7 @@ The hyper transformer is also capable of transforming all of the tables specifie
 6             115.0              1
 7             831.0              1
 ...
->>> reversed = ht.hyper_reverse_transform(tables=transformed)
+>>> reversed = ht.reverse_transform(tables=transformed)
 >>> print(reversed)
 {'sessions':        secs_elapsed
 0             319.0

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -24,7 +24,7 @@ class HyperTransformer:
         return getattr(globals()[class_name], class_name)
 
     def fit_transform(self, tables=None, transformer_dict=None,
-                            transformer_list=None, missing=True):
+                      transformer_list=None, missing=True):
         """
         This function loops applies all the specified transformers to the
         tables and return a dict of transformed tables

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -13,15 +13,18 @@ class HyperTransformer:
         """ initialize preprocessor """
 
         self.transformers = {}  # key=(table_name, col_name) val=transformer
-        if meta_file is not None:
-            self.table_dict = utils.get_table_dict(meta_file)
-            self.transformers_dict = utils.get_transformers_dict(meta_file)
+
+        if not meta_file:
+            raise ValueError("'meta_file' argument is needed to use HyperTransformer")
+
+        self.table_dict = utils.get_table_dict(meta_file)
+        self.transformers_dict = utils.get_transformers_dict(meta_file)
 
     def get_class(self, class_name):
         """ Gets class object of transformer from class name """
         return getattr(globals()[class_name], class_name)
 
-    def hyper_fit_transform(self, tables=None, transformer_dict=None,
+    def fit_transform(self, tables=None, transformer_dict=None,
                             transformer_list=None, missing=True):
         """
         This function loops applies all the specified transformers to the
@@ -51,7 +54,7 @@ class HyperTransformer:
             transformed[table_name] = transformed_table
         return transformed
 
-    def hyper_transform(self, tables, table_metas=None, missing=True):
+    def transform(self, tables, table_metas=None, missing=True):
         """
         This function applies all the saved transformers to the
         tables and returns a dict of transformed tables
@@ -73,7 +76,7 @@ class HyperTransformer:
                                                            missing)
         return transformed
 
-    def hyper_reverse_transform(self, tables, table_metas=None, missing=True):
+    def reverse_transform(self, tables, table_metas=None, missing=True):
         """Loops through the list of reverse transform functions and puts data
         back into original format.
 

--- a/rdt/transformers/BaseTransformer.py
+++ b/rdt/transformers/BaseTransformer.py
@@ -3,9 +3,10 @@ class BaseTransformer(object):
     a way that is machine learning friendly
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """ initialize preprocessor """
-        pass
+        self.type = kwargs.get('type')
+        self.col_name = None
 
     def fit_transform(self, col, col_meta, missing=True):
         """ Returns the processed table """

--- a/rdt/transformers/BaseTransformer.py
+++ b/rdt/transformers/BaseTransformer.py
@@ -13,7 +13,7 @@ class BaseTransformer(object):
 
     def transform(self, col, col_meta, missing=True):
         """ Does the required transformations to the data """
-        raise NotImplementedError
+        return self.fit_transform(col, col_meta, missing)
 
     def reverse_transform(self, col, col_meta, missing=True):
         """ Converts data back into original format """

--- a/rdt/transformers/CatTransformer.py
+++ b/rdt/transformers/CatTransformer.py
@@ -30,10 +30,6 @@ class CatTransformer(BaseTransformer):
             return res
         return out
 
-    def transform(self, col, col_meta, missing=True):
-        """ Does the required transformations to the data """
-        return self.fit_transform(col, col_meta, missing)
-
     def reverse_transform(self, col, col_meta, missing=True):
         """ Converts data back into original format """
         output = pd.DataFrame(columns=[])

--- a/rdt/transformers/CatTransformer.py
+++ b/rdt/transformers/CatTransformer.py
@@ -11,10 +11,9 @@ class CatTransformer(BaseTransformer):
     This class represents the categorical transformer for SDV
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """ initialize transformer """
-        super(CatTransformer, self).__init__()
-        self.type = 'categorical'
+        super().__init__(type='categorical', *args, **kwargs)
         self.probability_map = {}  # val -> ((a,b), mean, std)
 
     def fit_transform(self, col, col_meta, missing=True):

--- a/rdt/transformers/CatTransformer.py
+++ b/rdt/transformers/CatTransformer.py
@@ -74,13 +74,9 @@ class CatTransformer(BaseTransformer):
 
     def get_probability_map(self, col):
         """ Maps each unique value to probability of seeing it """
-        self.probability_map = {}
         # first get count of values
-        for val in col:
-            if val not in self.probability_map:
-                self.probability_map[val] = 1
-            else:
-                self.probability_map[val] += 1
+        self.probability_map = col.groupby(col).count().to_dict()
+
         # next set probability ranges on interval [0,1]
         cur = 0
         num_vals = len(col)

--- a/rdt/transformers/DTTransformer.py
+++ b/rdt/transformers/DTTransformer.py
@@ -13,11 +13,9 @@ class DTTransformer(BaseTransformer):
     This class represents the datetime transformer for SDV
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """ initialize transformer """
-        super(DTTransformer, self).__init__()
-        self.type = 'datetime'
-        self.col_name = None
+        super().__init__(type='datetime', *args, **kwargs)
         self.default_val = None
 
     def fit_transform(self, col, col_meta, missing=True):

--- a/rdt/transformers/DTTransformer.py
+++ b/rdt/transformers/DTTransformer.py
@@ -34,10 +34,6 @@ class DTTransformer(BaseTransformer):
             return res
         return out.to_frame(self.col_name)
 
-    def transform(self, col, col_meta, missing=True):
-        """ Does the required transformations to the data """
-        return self.fit_transform(col, col_meta, missing)
-
     def reverse_transform(self, col, col_meta, missing=True):
         """ Converts data back into original format """
         output = pd.DataFrame(columns=[])

--- a/rdt/transformers/NullTransformer.py
+++ b/rdt/transformers/NullTransformer.py
@@ -21,8 +21,8 @@ class NullTransformer(BaseTransformer):
         new_name = '?' + self.col_name
         out[new_name] = pd.notnull(col) * 1
         # replace missing values
-        if not pd.isnull(col.values.mean()):
-            clean_col = col.fillna(col.values.mean())
+        if not pd.isnull(col.mean()):
+            clean_col = col.fillna(col.mean())
         else:
             clean_col = col.fillna(0)
         out[self.col_name] = clean_col

--- a/rdt/transformers/NullTransformer.py
+++ b/rdt/transformers/NullTransformer.py
@@ -9,11 +9,9 @@ class NullTransformer(BaseTransformer):
     This class represents the datetime transformer for SDV
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """ initialize transformer """
-        super(NullTransformer, self).__init__()
-        self.type = ['datetime', 'number']
-        self.col_name = None
+        super().__init__(type=['datetime', 'number'], *args, **kwargs)
 
     def fit_transform(self, col, col_meta, **kwargs):
         """ Returns a tuple (transformed_table, new_table_meta) """

--- a/rdt/transformers/NullTransformer.py
+++ b/rdt/transformers/NullTransformer.py
@@ -15,7 +15,7 @@ class NullTransformer(BaseTransformer):
         self.type = ['datetime', 'number']
         self.col_name = None
 
-    def fit_transform(self, col, col_meta):
+    def fit_transform(self, col, col_meta, **kwargs):
         """ Returns a tuple (transformed_table, new_table_meta) """
         out = pd.DataFrame(columns=[])
         self.col_name = col_meta['name']
@@ -29,10 +29,6 @@ class NullTransformer(BaseTransformer):
             clean_col = col.fillna(0)
         out[self.col_name] = clean_col
         return out
-
-    def transform(self, col, col_meta):
-        """ Does the required transformations to the data """
-        return self.fit_transform(col, col_meta)
 
     def reverse_transform(self, col, col_meta):
         """ Converts data back into original format """

--- a/rdt/transformers/NumberTransformer.py
+++ b/rdt/transformers/NumberTransformer.py
@@ -44,10 +44,6 @@ class NumberTransformer(BaseTransformer):
         out = out.apply(self.get_val, axis=1)
         return out.to_frame(self.col_name)
 
-    def transform(self, col, col_meta, missing=True):
-        """ Does the required transformations to the data """
-        return self.fit_transform(col, col_meta, missing)
-
     def reverse_transform(self, col, col_meta, missing=True):
         """ Converts data back into original format """
         output = pd.DataFrame(columns=[])

--- a/rdt/transformers/NumberTransformer.py
+++ b/rdt/transformers/NumberTransformer.py
@@ -11,11 +11,9 @@ class NumberTransformer(BaseTransformer):
     This class represents the datetime transformer for SDV
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """ initialize transformer """
-        super(NumberTransformer, self).__init__()
-        self.type = 'number'
-        self.col_name = None
+        super().__init__(type='number', *args, **kwargs)
         self.default_val = None
         self.subtype = None
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -1,17 +1,13 @@
-# from DT_Transformer import DT_Transformer
-import importlib
-from os import listdir
-from os.path import isfile, join, realpath, dirname
+from rdt.transformers.BaseTransformer import BaseTransformer
+from rdt.transformers.CatTransformer import CatTransformer
+from rdt.transformers.DTTransformer import DTTransformer
+from rdt.transformers.NullTransformer import NullTransformer
+from rdt.transformers.NumberTransformer import NumberTransformer
 
-mypath = realpath(__file__)
-directory = dirname(mypath)
-onlyfiles = [f for f in listdir(directory) if isfile(join(directory, f))]
-array = []
-for file in onlyfiles:
-    if file.split('.')[1] == 'py' and file.split('.')[0] != '__init__':
-        array.append(file.split('.')[0])
-prefix = 'rdt.transformers.'
-
-for transformer in array:
-    mod = prefix + transformer
-    importlib.import_module(mod)
+__all__ = [
+    'BaseTransformer',
+    'CatTransformer',
+    'DTTransformer',
+    'NullTransformer',
+    'NumberTransformer'
+]


### PR DESCRIPTION
solves #27 :
- The first iteration of CatTransformer.get_probability_map can be changed to self.probability_map = col.groupby(col).count().to_dict()
- Transform method should be implemented on BaseTransformer and inherited on the other transformers.
- HyperTransformer should crash at init if no meta_file is provided. It will raise an Attribute later on, so it’s better doing it early. 
- HyperTransformer methods shouldn’t be prefixed with hyper.
- `rdt.transformers.__init__` should be replace with a proper module declaration.

Waiting first to merge PR #28 