### PR TITLE
Issue 34: Change reverse_transform method in NumberTransformer to handle nans

### DIFF
--- a/rdt/transformers/NumberTransformer.py
+++ b/rdt/transformers/NumberTransformer.py
@@ -100,6 +100,8 @@ class NumberTransformer(BaseTransformer):
                 val = sys.maxsize
             elif np.isneginf(val):
                 val = -sys.maxsize
+            if np.isnan(val):
+                val = self.default_val
             if meta == 'integer':
                 return int(round(val))
             return val

--- a/tests/rdt/transformers/test_NumberTransformer.py
+++ b/tests/rdt/transformers/test_NumberTransformer.py
@@ -79,6 +79,29 @@ class Test_NumberTransformer(unittest.TestCase):
         # Check
         assert result.equals(expected_result)
 
+    def test_reverse_transform_nan(self):
+        """FIXME: finish when number and null transformer are compatible"""
+        """ Checks the conversion of the data back into original format """
+
+        # Setup
+        col = pd.Series([34, 23, 27, 31, 39], name='age')
+        col_meta = {
+            'name': 'age',
+            'subtype': 'integer',
+            'type': 'number'
+        }
+        transformer = NumberTransformer()
+        transformer.fit_transform(col, col_meta, False)
+        col2 = pd.Series([34, 23, 27, 31, np.nan], name='age')
+
+        # Run
+        expected = pd.DataFrame({'age': [34, 23, 27, 31, transformer.default_val]})
+        print(expected)
+        result = transformer.reverse_transform(col2, col_meta, False)
+        print(result)
+        # Check
+        assert result.equals(expected)
+
     @unittest.skip("FIXME: when number and null transformer are compatible")
     def test_reverse_transform_missing(self):
         """FIXME: finish when number and null transformer are compatible"""

--- a/tests/rdt/transformers/test_NumberTransformer.py
+++ b/tests/rdt/transformers/test_NumberTransformer.py
@@ -80,8 +80,7 @@ class Test_NumberTransformer(unittest.TestCase):
         assert result.equals(expected_result)
 
     def test_reverse_transform_nan(self):
-        """FIXME: finish when number and null transformer are compatible"""
-        """ Checks the conversion of the data back into original format """
+        """Checks that nans are handled correctly in reverse transformation"""
 
         # Setup
         col = pd.Series([34, 23, 27, 31, 39], name='age')
@@ -96,9 +95,7 @@ class Test_NumberTransformer(unittest.TestCase):
 
         # Run
         expected = pd.DataFrame({'age': [34, 23, 27, 31, transformer.default_val]})
-        print(expected)
         result = transformer.reverse_transform(col2, col_meta, False)
-        print(result)
         # Check
         assert result.equals(expected)
 


### PR DESCRIPTION
Resolves #35 . This PR adds a check to the reverse_transform method of the dt.transformers.NumberTransformer class to make sure that nans are accounted for. If a nan is seen, then the default value of the transformer should be used.