### PR TITLE
Issue 39: Fixing KeyError: nan bug in CatTransformer

### DIFF
--- a/rdt/transformers/CatTransformer.py
+++ b/rdt/transformers/CatTransformer.py
@@ -20,9 +20,10 @@ class CatTransformer(BaseTransformer):
         """ Returns a tuple (transformed_table, new_table_meta) """
         out = pd.DataFrame()
         col_name = col_meta['name']
+        self.get_probability_map(col)
+
         # Make sure all nans are handled the same by replacing with None
         column = col.replace({np.nan: None})
-        self.get_probability_map(column)
         out[col_name] = column.apply(self.get_val)
         # Handle missing
 

--- a/rdt/transformers/CatTransformer.py
+++ b/rdt/transformers/CatTransformer.py
@@ -20,9 +20,8 @@ class CatTransformer(BaseTransformer):
         """ Returns a tuple (transformed_table, new_table_meta) """
         out = pd.DataFrame()
         col_name = col_meta['name']
-        # Make sure all nans are handled the same by replacing
-        # with -1
-        column = col.fillna(-1)
+        # Make sure all nans are handled the same by replacing with None
+        column = col.replace({np.nan: None})
         self.get_probability_map(column)
         out[col_name] = column.apply(self.get_val)
         # Handle missing
@@ -81,7 +80,8 @@ class CatTransformer(BaseTransformer):
     def get_probability_map(self, col):
         """ Maps each unique value to probability of seeing it """
 
-        self.probability_map = col.groupby(col).count().to_dict()
+        column = col.replace({np.nan: np.inf})
+        self.probability_map = column.groupby(column).count().rename({np.inf: None}).to_dict()
         # next set probability ranges on interval [0,1]
         cur = 0
         num_vals = len(col)

--- a/tests/rdt/transformers/test_CatTransformer.py
+++ b/tests/rdt/transformers/test_CatTransformer.py
@@ -195,4 +195,4 @@ class Test_CatTransformer(unittest.TestCase):
 
         # Check
         # the  nan value in the data should be in probability map
-        assert output is not None
+        assert None in transformer.probability_map

--- a/tests/rdt/transformers/test_CatTransformer.py
+++ b/tests/rdt/transformers/test_CatTransformer.py
@@ -191,7 +191,7 @@ class Test_CatTransformer(unittest.TestCase):
         }
         transformer = CatTransformer()
         # Run
-        output = transformer.fit_transform(data, col_meta)
+        transformer.fit_transform(data, col_meta)
 
         # Check
         # the  nan value in the data should be in probability map

--- a/tests/rdt/transformers/test_CatTransformer.py
+++ b/tests/rdt/transformers/test_CatTransformer.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 
 from rdt.transformers.CatTransformer import CatTransformer
@@ -178,3 +179,20 @@ class Test_CatTransformer(unittest.TestCase):
             # Mean is middle point
             # We check this way because of floating point issues
             assert (mean - interval[0]) - (interval[1] - mean) < 1 / 1E9
+
+    def test_fit_transform_val_nan(self):
+        """Tests that nans are handled by fit_transform method"""
+
+        # Setup
+        data = pd.Series([np.nan, 1, 5])
+        col_meta = {
+            "name": "breakfast",
+            "type": "categorical"
+        }
+        transformer = CatTransformer()
+        # Run
+        output = transformer.fit_transform(data, col_meta)
+
+        # Check
+        # the  nan value in the data should be in probability map
+        assert output is not None


### PR DESCRIPTION
Fixes #39. Sometimes nan values are loaded as type <class 'numpy.float64'> and other times as type <class 'float'>. The CatTransformer should handle all nan types the same since they are all mapped to the same category in the get_probability_map method. This PR fixes this by simply mapping all nan types to -1 and using that as the key in the probability map instead.