### PR TITLE
Issue 41: Out of bounds timestamp in DTTransformer

### DIFF
--- a/rdt/transformers/DTTransformer.py
+++ b/rdt/transformers/DTTransformer.py
@@ -25,7 +25,7 @@ class DTTransformer(BaseTransformer):
         self.col_name = col_meta['name']
 
         # if are just processing child rows, then the name is already known
-        out[self.col_name] = pd.to_datetime(col)
+        out[self.col_name] = pd.to_datetime(col, errors='coerce')
         out = out.apply(self.get_val, axis=1)
 
         # Handle missing

--- a/tests/rdt/transformers/test_DTTransformer.py
+++ b/tests/rdt/transformers/test_DTTransformer.py
@@ -46,6 +46,23 @@ class DTTransformerTest(TestCase):
         # load correct answer
         self.assertTrue(np.allclose(result, predicted, 1e-03))
 
+    def test_fit_transform_out_of_bounds(self):
+        """Tests that out of bounds time stamps get transformed"""
+        out_of_bounds_data = pd.Series(['2262-04-11 23:47:16.854775807',
+                                        '2263-04-11 23:47:16.854775808'])
+        out_of_bounds_meta = {
+            "name": "date_first_booking",
+            "type": "datetime",
+            "format": "%Y-%m-%d",
+        }
+
+        transformed = self.transformer.fit_transform(out_of_bounds_data,
+                                                     out_of_bounds_meta)
+        predicted = transformed[out_of_bounds_meta['name']]
+        expected = pd.Series([9.223386e+18, 0.000000e+00])
+        # load correct answer
+        self.assertTrue(np.allclose(expected, predicted, 1e-03))
+
     def test_reverse_transform(self):
         """ """
 


### PR DESCRIPTION
Fixes #41 . Line 28 of https://github.com/HDI-Project/RDT/blob/7bc38da2c9cd737fdd2ff3207d3cd3482701bb6d/rdt/transformers/DTTransformer.py#L28 sometimes throws a pandas.tslib.OutOfBoundsDatetime error because certain timestamp values are out of range. This PR fixes this problem by setting the out of bounds values as NaT.