### PR TITLE
Issue 43: handling nans in reverse transformation of DTTransformer

### DIFF
--- a/rdt/transformers/DTTransformer.py
+++ b/rdt/transformers/DTTransformer.py
@@ -24,6 +24,10 @@ class DTTransformer(BaseTransformer):
         out = pd.DataFrame()
         self.col_name = col_meta['name']
 
+        # get default val
+        val = col.groupby(col).count().index[0]
+        tmp = parser.parse(str(val)).timetuple()
+        self.default_val = time.mktime(tmp) * 1e9
         # if are just processing child rows, then the name is already known
         out[self.col_name] = pd.to_datetime(col)
         out = out.apply(self.get_val, axis=1)
@@ -81,6 +85,8 @@ class DTTransformer(BaseTransformer):
 
         def safe_date(x):
             t = x[col]
+            if np.isnan(t):
+                t = self.default_val
             if np.isposinf(t):
                 t = sys.maxsize
             elif np.isneginf(t):

--- a/tests/rdt/transformers/test_DTTransformer.py
+++ b/tests/rdt/transformers/test_DTTransformer.py
@@ -84,14 +84,14 @@ class DTTransformerTest(TestCase):
         self.transformer.fit_transform(raw, self.normal_meta)
 
         col = pd.Series([1.3885524e+18,
-                          1.3885524e+18,
-                          1.3887252e+18,
-                          1.3887252e+18,
-                          np.nan], name='date_account_created')
+                         1.3885524e+18,
+                         1.3887252e+18,
+                         1.3887252e+18,
+                         np.nan], name='date_account_created')
 
         # Run
         result = self.transformer.reverse_transform(col, self.normal_meta, False)
-        expected =  pd.DataFrame({'date_account_created': [
+        expected = pd.DataFrame({'date_account_created': [
             '01/01/14',
             '01/01/14',
             '01/03/14',

--- a/tests/rdt/transformers/test_DTTransformer.py
+++ b/tests/rdt/transformers/test_DTTransformer.py
@@ -70,6 +70,37 @@ class DTTransformerTest(TestCase):
 
         assert result.equals(expected_result)
 
+    def test_reverse_transform_nan(self):
+        """Checks that nans are handled correctly in reverse transformation"""
+
+        # Setup
+        raw = pd.Series([
+            '01/01/14',
+            '01/02/14',
+            '01/03/14',
+            '01/04/14',
+        ], name='date_account_created'
+        )
+        self.transformer.fit_transform(raw, self.normal_meta)
+
+        col = pd.Series([1.3885524e+18,
+                          1.3885524e+18,
+                          1.3887252e+18,
+                          1.3887252e+18,
+                          np.nan], name='date_account_created')
+
+        # Run
+        result = self.transformer.reverse_transform(col, self.normal_meta, False)
+        expected =  pd.DataFrame({'date_account_created': [
+            '01/01/14',
+            '01/01/14',
+            '01/03/14',
+            '01/03/14',
+            '01/01/14'
+        ]})
+        # Check
+        assert result.equals(expected)
+
     def test_fit_transform_missing(self):
         # get truncated column
         result = pd.Series([np.nan,


### PR DESCRIPTION
Solves #43 . If a nan value is passed into the safe_data method on line 88, then an error will be raised. To solve this, we create a default value for the transformer and use that instead in place of the nan if a nan is given.