### PR TITLE
Issue 47: Enforcing dtype int for subtype int on NumberTransformer

### DIFF
--- a/rdt/transformers/NumberTransformer.py
+++ b/rdt/transformers/NumberTransformer.py
@@ -44,6 +44,10 @@ class NumberTransformer(BaseTransformer):
             return out
 
         out = out.apply(self.get_val, axis=1)
+
+        if self.subtype == 'int':
+            out[self.col_name] = out[self.col_name].astype(int)
+
         return out.to_frame(self.col_name)
 
     def reverse_transform(self, col, col_meta, missing=True):
@@ -63,6 +67,9 @@ class NumberTransformer(BaseTransformer):
         else:
             data = col.to_frame()
             output[col_name] = data.apply(fn, axis=1)
+
+        if self.subtype == 'int':
+            output[self.col_name] = output[self.col_name].astype(int)
 
         return output
 


### PR DESCRIPTION
Simply added checks that if the subtype is `int` the column is casted to `int` to avoid problems with pandas automatic casting of column.

Resolves #47 