### PR TITLE
Issue 38: add support for python3.7

### DIFF
--- a/rdt/transformers/DTTransformer.py
+++ b/rdt/transformers/DTTransformer.py
@@ -94,7 +94,7 @@ class DTTransformer(BaseTransformer):
 
         self.check_data_type(col_meta)
 
-        output = pd.DataFrame()
+        output = pd.DataFrame(index=col.index)
         date_format = col_meta['format']
 
         fn = self.get_date_converter(self.col_name, date_format)

--- a/rdt/transformers/NullTransformer.py
+++ b/rdt/transformers/NullTransformer.py
@@ -36,9 +36,9 @@ class NullTransformer(BaseTransformer):
         Returns:
             pandas.DataFrame
         """
-        out = pd.DataFrame()
-        out[self.new_name] = (pd.notnull(col) * 1).astype(int)
+        out = pd.DataFrame(index=col.index)
         out[self.col_name] = col.fillna(self.default_value)
+        out[self.new_name] = (pd.notnull(col) * 1).astype(int)
         return out
 
     def reverse_transform(self, col, col_meta):

--- a/rdt/transformers/NumberTransformer.py
+++ b/rdt/transformers/NumberTransformer.py
@@ -47,7 +47,7 @@ class NumberTransformer(BaseTransformer):
         missing = missing if missing is not None else self.missing
         self.check_data_type(col_meta)
 
-        out = pd.DataFrame()
+        out = pd.DataFrame(index=col.index)
 
         # if are just processing child rows, then the name is already known
         out[self.col_name] = col[self.col_name]
@@ -83,7 +83,7 @@ class NumberTransformer(BaseTransformer):
 
         self.check_data_type(col_meta)
 
-        output = pd.DataFrame(columns=[])
+        output = pd.DataFrame(index=col.index)
         subtype = col_meta['subtype']
         col_name = col_meta['name']
         fn = self.get_number_converter(col_name, subtype)

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ with open('HISTORY.md') as history_file:
     history = history_file.read()
 
 install_requires = [
-    'numpy==1.13.1',
-    'pandas==0.22.0',
-    'scipy==0.19.1',
+    'numpy==1.15.4',
+    'pandas==0.23.4',
+    'scipy==1.1.0',
 ]
 
 setup_requires = [
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     description="A repository with reversible data transforms",
     extras_require={

--- a/tests/rdt/test_hypertransformer.py
+++ b/tests/rdt/test_hypertransformer.py
@@ -163,7 +163,7 @@ class TestHyperTransformer(TestCase):
                 '?age': [1, 0, 0, 0, 0],
                 'age': [62, 62, 62, 62, 62]
             },
-            columns=['?age', 'age']
+            columns=['age', '?age']
         )
 
         # Run

--- a/tests/rdt/transformers/test_NullTransformer.py
+++ b/tests/rdt/transformers/test_NullTransformer.py
@@ -27,10 +27,13 @@ class TestNullTransformer(unittest.TestCase):
         }
         transformer = NullTransformer()
 
-        expected_result = pd.DataFrame({
-            'age': [62.0, 62.0, 62.0, 62.0, 62.0],
-            '?age': [1, 0, 0, 0, 0]
-        })
+        expected_result = pd.DataFrame(
+            {
+                'age': [62.0, 62.0, 62.0, 62.0, 62.0],
+                '?age': [1, 0, 0, 0, 0]
+            },
+            columns=['age', '?age']
+        )
 
         # Run
         result = transformer.fit_transform(col, col_meta)
@@ -49,10 +52,13 @@ class TestNullTransformer(unittest.TestCase):
         }
         transformer = NullTransformer()
 
-        expected_result = pd.DataFrame({
-            'age': [62.0, 53.0, 53.0, 45.0, 53.25],
-            '?age': [1, 1, 1, 1, 0]
-        })
+        expected_result = pd.DataFrame(
+            {
+                'age': [62.0, 53.0, 53.0, 45.0, 53.25],
+                '?age': [1, 1, 1, 1, 0]
+            },
+            columns=['age', '?age']
+        )
 
         # Run
         result = transformer.fit_transform(col, col_meta)

--- a/tests/rdt/transformers/test_NumberTransformer.py
+++ b/tests/rdt/transformers/test_NumberTransformer.py
@@ -50,10 +50,12 @@ class TestNumberTransformer(unittest.TestCase):
             "subtype": "integer",
         }
         transformer = NumberTransformer()
-        expected_result = pd.DataFrame({
-            'age': [62, 27, 46, 34, 62],
-            '?age': [1, 1, 0, 1, 1]
-        })
+        expected_result = pd.DataFrame(
+            {
+                'age': [62, 27, 46, 34, 62],
+                '?age': [1, 1, 0, 1, 1]
+            },
+            columns=['age', '?age'])
 
         # Run
         result = transformer.fit_transform(col, col_meta, True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py35, py36, lint, docs
+envlist = py35, py36, py37, lint, docs
 
 
 [travis]
 python =
+    3.7: py37
     3.6: py36, lint, docs
     3.5: py35
 


### PR DESCRIPTION
Add suport to python3.7. Between other changes:
- Updated requirements to compatible ones.
- Add `tox` environment for py37 ( not on TravisCI as it's not fully supported yet)
- Minor changes to ensure compatibility between versions.

TravisCI hasn't been updated because it's not compatible with python3.7 yet.

Resolves #38 