### PR TITLE
Issue 57: remove missing argument transformers

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -3,16 +3,14 @@ class BaseTransformer(object):
 
     type = None
 
-    def __init__(self, column_metadata, missing=True):
+    def __init__(self, column_metadata):
         """Initialize preprocessor.
 
         Args:
             column_metadata(dict): Meta information of the column.
-            missing(bool): Wheter or not handle missing values using NullTransformer.
             transformer_type(str): Type of data the transformer is able to transform.
         """
         self.column_metadata = column_metadata
-        self.missing = missing
         self.col_name = column_metadata['name']
 
         self.check_data_type()

--- a/rdt/transformers/category.py
+++ b/rdt/transformers/category.py
@@ -4,7 +4,6 @@ from faker import Faker
 from scipy.stats import norm
 
 from rdt.transformers.base import BaseTransformer
-from rdt.transformers.null import NullTransformer
 
 
 class CatTransformer(BaseTransformer):
@@ -12,7 +11,6 @@ class CatTransformer(BaseTransformer):
 
     Args:
         column_metadata(dict): Meta information of the column.
-        missing(bool): Wheter or not handle missing values using NullTransformer.
         anonymize (bool): Wheter or not replace the values of col before generating the
                           categorical_map.
 
@@ -22,10 +20,10 @@ class CatTransformer(BaseTransformer):
 
     type = 'categorical'
 
-    def __init__(self, column_metadata, missing=True, anonymize=False, category=None):
+    def __init__(self, column_metadata, anonymize=False, category=None):
         """Initialize transformer."""
 
-        super().__init__(column_metadata, missing)
+        super().__init__(column_metadata)
 
         if anonymize and not category:
             raise ValueError('`category` must be specified if `anonymize` is True')
@@ -143,12 +141,6 @@ class CatTransformer(BaseTransformer):
         # Make sure all nans are handled the same by replacing with None
         column = col[self.col_name].replace({np.nan: None})
         out[self.col_name] = column.apply(self.get_val)
-        # Handle missing
-
-        if self.missing:
-            nt = NullTransformer(self.column_metadata)
-            res = nt.fit_transform(out)
-            return res
 
         return out
 
@@ -168,7 +160,7 @@ class CatTransformer(BaseTransformer):
         self._fit(col)
         return self.transform(col)
 
-    def reverse_transform(self, col, column_metadata=None, missing=None):
+    def reverse_transform(self, col, column_metadata=None):
         """Converts data back into original format.
 
         Args:
@@ -180,15 +172,7 @@ class CatTransformer(BaseTransformer):
 
         output = pd.DataFrame()
         new_col = self.get_category(col[self.col_name])
-
-        if missing:
-            new_col = new_col.rename(self.col_name)
-            data = pd.concat([new_col, col['?' + self.col_name]], axis=1)
-            nt = NullTransformer(self.column_metadata)
-            output[self.col_name] = nt.reverse_transform(data)
-
-        else:
-            output[self.col_name] = new_col
+        output[self.col_name] = new_col
 
         return output
 

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -19,12 +19,16 @@ class NullTransformer(BaseTransformer):
         if isinstance(col, pd.DataFrame):
             col = col[self.col_name]
 
-        mean = col.mean()
+        if self.column_metadata['type'] == 'number':
+            mean = col.mean()
 
-        if not pd.isnull(mean) and self.column_metadata['type'] == 'number':
-            self.default_value = mean
+            if pd.notnull(mean):
+                self.default_value = mean
+
+            else:
+                self.default_value = 0
         else:
-            self.default_value = 0
+            self.default_value = col.mode().iloc[0]
 
     def transform(self, col):
         """Prepare the transformer to convert data and return the processed table.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,18 @@
+def safe_compare_dataframes(first, second):
+    """Compare two dataframes even if they have NaN values.
+
+    Args:
+        first (pandas.DataFrame): DataFrame to compare
+        second (pandas.DataFrame): DataFrame to compare
+
+    Returns:
+        bool
+    """
+
+    if first.isnull().all().all():
+        return first.equals(second)
+
+    else:
+        nulls = (first.isnull() == second.isnull()).all().all()
+        values = (first[~first.isnull()] == second[~second.isnull()]).all().all()
+        return nulls and values

--- a/tests/rdt/test_hypertransformer.py
+++ b/tests/rdt/test_hypertransformer.py
@@ -240,6 +240,7 @@ class TestHyperTransformer(TestCase):
                         assert missing in table.columns
                         assert (values[column].isnull() == (table[missing] == 0)).all()
 
+    @skip('https://github.com/HDI-Project/RDT/issues/49')
     def test_reverse_transform(self):
         """reverse_transform leave transformed data in its original state."""
         # Setup

--- a/tests/rdt/transformers/test_category.py
+++ b/tests/rdt/transformers/test_category.py
@@ -109,7 +109,7 @@ class TestCatTransformer(TestCase):
         })
 
         # Run
-        result = transformer.fit_transform(col, column_metadata, False)
+        result = transformer.fit_transform(col)
 
         # Check
         assert result.equals(expected_result)
@@ -131,7 +131,7 @@ class TestCatTransformer(TestCase):
         }
 
         # Run
-        result = transformer.fit_transform(original_column, column_metadata, missing=True)
+        result = transformer.fit_transform(original_column)
 
         # Check
         assert original_column.equals(result)
@@ -144,7 +144,7 @@ class TestCatTransformer(TestCase):
             "name": "breakfast",
             "type": "categorical"
         }
-        transformer = CatTransformer(column_metadata, missing=False)
+        transformer = CatTransformer(column_metadata)
         transformer.probability_map = {
             'A': ((0.6, 1.0), 0.8, 0.0666),
             'B': ((0, 0.6), 0.3, 0.0999)
@@ -172,7 +172,7 @@ class TestCatTransformer(TestCase):
             "name": "breakfast",
             "type": "categorical"
         }
-        transformer = CatTransformer(column_metadata=column_metadata, missing=False)
+        transformer = CatTransformer(column_metadata=column_metadata)
         transformer.probability_map = {
             'A': ((0.6, 1.0), 0.8, 0.0666),
             'B': ((0, 0.6), 0.3, 0.0999)
@@ -301,7 +301,7 @@ class TestCatTransformer(TestCase):
             'type': 'categorical'
         }
         transformer = CatTransformer(
-            column_metadata=column_metadata, missing=False, anonymize=True, category='first_name')
+            column_metadata=column_metadata, anonymize=True, category='first_name')
 
         data = pd.DataFrame({
             'first_name': ['Albert', 'John', 'Michael']
@@ -325,9 +325,9 @@ class TestCatTransformer(TestCase):
             'name': 'first_name',
             'type': 'categorical'
         }
-        transformer = CatTransformer(column_metadata=column_metadata, missing=False)
+        transformer = CatTransformer(column_metadata=column_metadata)
         anon_transformer = CatTransformer(
-            column_metadata=column_metadata, missing=False, anonymize=True, category='first_name')
+            column_metadata=column_metadata, anonymize=True, category='first_name')
 
         data = pd.DataFrame({
             'first_name': ['Albert', 'John', 'Michael']

--- a/tests/rdt/transformers/test_number.py
+++ b/tests/rdt/transformers/test_number.py
@@ -36,33 +36,8 @@ class TestNumberTransformer(unittest.TestCase):
             "type": "number",
             "subtype": "integer",
         }
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         expected_result = pd.DataFrame({'age': [62, 27, 5, 34, 62]})
-
-        # Run
-        result = transformer.fit_transform(col)
-
-        # Check
-        assert result.equals(expected_result)
-
-    def test_fit_transform_missing(self):
-        """Sets internal state and transforms data with missing values."""
-        # Setup
-        col = pd.DataFrame({
-            'age': [62, 27, np.nan, 34, 62],
-        })
-        column_metadata = {
-            "name": "age",
-            "type": "number",
-            "subtype": "integer",
-        }
-        transformer = NumberTransformer(column_metadata, missing=True)
-        expected_result = pd.DataFrame(
-            {
-                'age': [62, 27, 46, 34, 62],
-                '?age': [1, 1, 0, 1, 1]
-            },
-            columns=['age', '?age'])
 
         # Run
         result = transformer.fit_transform(col)
@@ -81,7 +56,7 @@ class TestNumberTransformer(unittest.TestCase):
             'subtype': 'integer',
             'type': 'number'
         }
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         expected_result = pd.DataFrame({'age': [34, 23, 27, 31, 39]})
 
         # Run
@@ -101,7 +76,7 @@ class TestNumberTransformer(unittest.TestCase):
             'subtype': 'integer',
             'type': 'number'
         }
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         transformer.fit_transform(col)
 
         col2 = pd.DataFrame({
@@ -114,27 +89,6 @@ class TestNumberTransformer(unittest.TestCase):
 
         # Run
         result = transformer.reverse_transform(col2)
-
-        # Check
-        assert result.equals(expected_result)
-
-    def test_reverse_transform_missing(self):
-        """Sets internal state and transforms data with missing values."""
-        # Setup
-        col = pd.DataFrame({
-            'age': [34, 23, 0, 31, 39],
-            '?age': [1, 1, 0, 1, 1]
-        })
-        column_metadata = {
-            'name': 'age',
-            'subtype': 'integer',
-            'type': 'number'
-        }
-        transformer = NumberTransformer(column_metadata, missing=True)
-        expected_result = pd.DataFrame({'age': [34, 23, np.nan, 31, 39]})
-
-        # Run
-        result = transformer.reverse_transform(col)
 
         # Check
         assert result.equals(expected_result)
@@ -152,7 +106,7 @@ class TestNumberTransformer(unittest.TestCase):
             'type': 'number'
         }
 
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         transformer.fit(col)
         expected_result = pd.Series([62, 35, 24])
 
@@ -175,7 +129,7 @@ class TestNumberTransformer(unittest.TestCase):
             'type': 'number'
         }
 
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         transformer.fit(col)
         expected_result = pd.Series([62.5, 35.5, 24.3])
 
@@ -220,7 +174,7 @@ class TestNumberTransformer(unittest.TestCase):
             'type': 'number'
         }
 
-        transformer = NumberTransformer(column_metadata, missing=False)
+        transformer = NumberTransformer(column_metadata)
         transformer.default_val = 999
         expected_result = pd.Series([4, 999, 13])
 


### PR DESCRIPTION
The argument missing has been removed from the basic transformers, and now all transformation of missing/null values are done in the hypertransformer scope.

Resolves #57 