### PR TITLE
if the data type is ndarray transform it into a pandas series

### DIFF
--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -77,5 +77,8 @@ class BooleanTransformer(BaseTransformer):
         if self.nan is not None:
             data = self.null_transformer.reverse_transform(data)
 
+        if isinstance(data, np.ndarray):
+            data = pd.Series(data)
+
         data[pd.notnull(data)] = np.round(data[pd.notnull(data)]).astype(bool)
         return data

--- a/tests/transformers/test_boolean.py
+++ b/tests/transformers/test_boolean.py
@@ -165,3 +165,20 @@ class TestBooleanTransformer(TestCase):
             expect_call_count,
             "NullTransformer.reverse_transform should not be called when nan is ignore"
         )
+
+    def test_reverse_transform_not_null_values(self):
+        """Test reverse_transform not null values correctly"""
+        # Setup
+        data = np.array([1., 0., 1.])
+
+        # Run
+        transformer = Mock()
+        transformer.nan = None
+
+        result = BooleanTransformer.reverse_transform(transformer, data)
+
+        # Asserts
+        expected = np.array([True, False, True])
+
+        assert type(result) == pd.Series
+        np.testing.assert_equal(result.to_numpy(), expected)


### PR DESCRIPTION
Resolves #103 

When the data is `numpy.ndarray`, transform the data into `pandas.Series`.